### PR TITLE
Fix mobile navigation menu

### DIFF
--- a/pages/header-page.ts
+++ b/pages/header-page.ts
@@ -33,10 +33,16 @@ export class HeaderPage {
 
   async openPageFromMenu(pageMeta: PageMeta, isMobile = false) {
     if (isMobile) {
-      this.hamburgerMenu.click();
-      await this.mobileTopNavigationCategory.filter({ hasText: this.eSGKpiEngine.topCategory }).click();
-      await this.mobileSideNavigationCategory.filter({ hasText: this.eSGKpiEngine.sideCategory }).click();
-      await this.mobileColumnNavigationCategory.filter({ hasText: this.eSGKpiEngine.name }).click();
+      await this.hamburgerMenu.click();
+      await this.mobileTopNavigationCategory
+        .filter({ hasText: pageMeta.topCategory })
+        .click();
+      await this.mobileSideNavigationCategory
+        .filter({ hasText: pageMeta.sideCategory })
+        .click();
+      await this.mobileColumnNavigationCategory
+        .filter({ hasText: pageMeta.name })
+        .click();
     } else {
       await this.topNavigationCategory.filter({ hasText: pageMeta.topCategory }).click();
       await this.sideNavigationCategory.filter({ hasText: pageMeta.sideCategory }).click();


### PR DESCRIPTION
## Summary
- ensure the mobile menu uses the provided page meta
- await the hamburger menu click for stability

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686634db71108320a0f665e79b2c4596